### PR TITLE
Update selections.py

### DIFF
--- a/pymms/sdc/selections.py
+++ b/pymms/sdc/selections.py
@@ -475,7 +475,7 @@ def combine_segments(data, delta_t=0):
     #   - Use itertools.islice to select start index without copying array
     for idx, t_delta in enumerate(t_deltas):
         # Contiguous segments are separated by delta_t seconds
-        if t_delta == delta_t:
+        if t_delta <= delta_t:
             # And unique segments have the same fom and discussion
             if (data[icontig].fom == data[idx+1].fom) and \
                     (data[icontig].discussion == data[idx+1].discussion):


### PR DESCRIPTION
Sent you an email about this, but should this be changed to t_delta<=delta_t? If continuous selections are adjacent but separated by less than what you determine the minimum separation between selections to be, shouldn’t they be included in the continuous selection?

Right now, I can’t use that method to combine the selections from mp-dl-unh, since each selection is separated by 4.5s (and thus time deltas alternate between 4.0 and 5.0 seconds).